### PR TITLE
Fix undefined variable name benchmarking_controller.rb

### DIFF
--- a/app/controllers/benchmarking_controller.rb
+++ b/app/controllers/benchmarking_controller.rb
@@ -49,7 +49,7 @@ class BenchmarkingController < ApplicationController
 
   def comment_create
     @post = Post.where("id >= ?", rand(Post.minimum(:id)..Post.maximum(:id))).limit(1).first
-    comment = Comment.create!(user: @user, post: post, body: "Comment #{request.uuid}")
+    comment = Comment.create!(user: @user, post: @post, body: "Comment #{request.uuid}")
     render "posts/show", status: :ok
   end
 


### PR DESCRIPTION
When I POST to `/benchmarking/write_heavy` multiple times, I see the following error roughly 25% of the time (the sample rate for `comment_create`).

```
NameError (undefined local variable or method `post' for #<BenchmarkingController:0x0000000000b540>):
```

The fix updates the variable reference to `@post`.

---

Great job at your RailsConf workshop!